### PR TITLE
remove unnecessary exec to start daemontools

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -6,14 +6,6 @@ class daemontools::package {
 
   package {'daemontools-run':
     ensure  => present,
-    require => Package['daemontools'],
-    notify  => Exec['daemontools-start'],
+    require => Package['daemontools']
   }
-
-  exec {'daemontools-start':
-    command     => "/usr/bin/sudo bash -cf '/usr/bin/svscanboot &'",
-    refreshonly => true,
-    require     => Package['daemontools'],
-  }
-
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "jbussdieker-daemontools",
-  "version": "0.0.3",
+  "version": "0.2.0-ens",
   "author": "Joshua B. Bussdieker",
   "summary": "Daemontools Module",
   "license": "Apache-2.0",


### PR DESCRIPTION
This is handled by the daemontools-run package that is installed in this manifest.
